### PR TITLE
invoke callback in onload handler not in try-catch block

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,6 @@ loader.load = function ( config, callback ) {
             json = JSON.parse(xhr.responseText);
 
             prepare(json);
-            callback(null);
 
             // there are some listeners
             if ( loader.events['load'] ) {
@@ -94,6 +93,8 @@ loader.load = function ( config, callback ) {
         } catch ( error ) {
             xhr.onerror(error);
         }
+        
+        callback(null);
     };
 
     xhr.ontimeout = xhr.onerror = function ( error ) {


### PR DESCRIPTION
Because if callback throws exception, it causes to invoke twice calls of callback, second time in xhr.onerror.
I want to view this exception in main tread of application to fix it faster.